### PR TITLE
In ruby 3, * when followed by super compacts the arguments to super

### DIFF
--- a/lib/zero_downtime_migrations/data.rb
+++ b/lib/zero_downtime_migrations/data.rb
@@ -1,6 +1,6 @@
 module ZeroDowntimeMigrations
   module Data
-    def initialize(*)
+    def initialize(*, **, &block)
       Migration.data = true
       super
     end

--- a/lib/zero_downtime_migrations/migration.rb
+++ b/lib/zero_downtime_migrations/migration.rb
@@ -6,7 +6,7 @@ module ZeroDowntimeMigrations
       mod.singleton_class.prepend(DSL)
     end
 
-    def initialize(*)
+    def initialize(*, **, &block)
       ActiveRecord::Base.send(:prepend, Data)
       ActiveRecord::Relation.send(:prepend, Relation)
       super
@@ -16,7 +16,7 @@ module ZeroDowntimeMigrations
       !!disable_ddl_transaction
     end
 
-    def define(*)
+    def define(*, **, &block)
       Migration.current = self
       Migration.safe = true
       super.tap { Migration.current = nil }

--- a/lib/zero_downtime_migrations/relation.rb
+++ b/lib/zero_downtime_migrations/relation.rb
@@ -2,7 +2,7 @@ module ZeroDowntimeMigrations
   module Relation
     prepend Data
 
-    def each(*)
+    def each(*, **, &block)
       Validation.validate!(:find_each)
       super
     end


### PR DESCRIPTION
This means they are passed to the eigenclass's representation of
the method as an array of the args and the kwargs which in ruby 3
causes an argument error